### PR TITLE
81 epic authentication test

### DIFF
--- a/epic-integration/build.gradle.kts
+++ b/epic-integration/build.gradle.kts
@@ -18,6 +18,10 @@ application {
     mainClass.set("com.backend.ApplicationKt")
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 repositories {
     mavenCentral()
 }
@@ -28,6 +32,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("io.ktor:ktor-server-tests:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
+
 
     //self imported plugins
     //this is for searialization with kotlinx

--- a/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
+++ b/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
@@ -16,25 +16,28 @@ import io.ktor.client.call.*
 
 class EpicCommunication {
 
-
     private val ctx: FhirContext = FhirContext.forR4()
     private val client = HttpClient()
 
-    //this works for getting the xml from the epic server (use hapi fhir to make it a resource?)
-    suspend fun patientSearch(given: String, family :String, birthdate : String, format : String = "json") :String{
-        // birthdate format yyyy-mm-dd
-        val token :String =  runBlocking { getEpicAccessToken() }
-
-        val response : HttpResponse = client.get("https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/Patient?given=$given&family=$family&birthdate=$birthdate&_format=$format"){
-            headers{
-                append(HttpHeaders.Authorization, "Bearer $token")
+    /**
+     * Makes an HTTP response request to the epic server at fhir.epic.com
+     * Returns a patient object on String format.
+     * As default the format returned is JSON (but XML can be returned by setting format to = "xml")
+     * Birthdate format yyyy-mm-dd
+     */
+    suspend fun patientSearch(givenName: String, familyName: String, birthdate: String, outputFormat: String = "json"): String {
+        val token: String = runBlocking { getEpicAccessToken() }
+        val response: HttpResponse =
+            client.get("https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/Patient?" +
+                    "given=$givenName&" +
+                    "family=$familyName&" +
+                    "birthdate=$birthdate&" +
+                    "_format=$outputFormat") {
+                headers {
+                    append(HttpHeaders.Authorization, "Bearer $token")
+                }
             }
-        }
-
-        val xmlString = response.receive<String>()
-        println(xmlString)
-
-        return xmlString
+        return response.receive()
     }
 
     fun parseBundleXMLToPatient(xmlMessage: String): Patient {

--- a/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
+++ b/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
@@ -21,11 +21,11 @@ class EpicCommunication {
     private val client = HttpClient()
 
     //this works for getting the xml from the epic server (use hapi fhir to make it a resource?)
-    suspend fun patientSearch(given: String, family :String, birthdate : String) :String{
+    suspend fun patientSearch(given: String, family :String, birthdate : String, format : String = "json") :String{
         // birthdate format yyyy-mm-dd
         val token :String =  runBlocking { getEpicAccessToken() }
 
-        val response : HttpResponse = client.get("https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/Patient?given=$given&family=$family&birthdate=$birthdate&_format=json"){
+        val response : HttpResponse = client.get("https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/Patient?given=$given&family=$family&birthdate=$birthdate&_format=$format"){
             headers{
                 append(HttpHeaders.Authorization, "Bearer $token")
             }

--- a/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
+++ b/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
@@ -30,6 +30,7 @@ class EpicCommunication {
                 append(HttpHeaders.Authorization, "Bearer $token")
             }
         }
+
         val xmlString = response.receive<String>()
         println(xmlString)
 

--- a/epic-integration/src/test/kotlin/com/backend/ApplicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/ApplicationTest.kt
@@ -8,6 +8,15 @@ import io.ktor.request.*
 import kotlin.test.*
 import io.ktor.server.testing.*
 import com.backend.plugins.*
+import com.google.common.base.Predicates.instanceOf
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
 
 class ApplicationTest {
+
+    @Test
+    fun testAuthentication() = withTestApplication(Application::main) {
+        assertThat(runBlocking { getEpicAccessToken() }, instanceOf(String::class.java))
+    }
+
 }

--- a/epic-integration/src/test/kotlin/com/backend/ApplicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/ApplicationTest.kt
@@ -11,12 +11,15 @@ import com.backend.plugins.*
 import com.google.common.base.Predicates.instanceOf
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.function.Executable
 
 class ApplicationTest {
 
     @Test
-    fun testAuthentication() = withTestApplication(Application::main) {
-        assertThat(runBlocking { getEpicAccessToken() }, instanceOf(String::class.java))
+    fun testAuthentication() {
+        // Asserts that getEpicAccessToken() runs without throwing any exceptions
+        assertAll(Executable { runBlocking { getEpicAccessToken() } })
     }
 
 }

--- a/epic-integration/src/test/kotlin/com/backend/EnvironmentVariablesTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EnvironmentVariablesTest.kt
@@ -1,0 +1,30 @@
+package com.backend
+
+import com.backend.plugins.getEpicAccessToken
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class EnvironmentVariablesTest {
+
+    @Test
+    fun `Environment variables should be accessible in the test environment`() {
+        /**
+         * If this test fails then the environment variables are not accessible in the test environment (or not at all).
+         * To add the environment variables to all future test evironments, go to:
+         *  - Run | Edit Configurations | Edit configuration templates | Gradle
+         *
+         * From there, add the environment variables.
+         * Remove all Gradle run configurations that were made before editing the template.
+         * Rerun the test. It should now have access to the variables.
+         */
+        val privateKey = System.getenv("epic_private_key")
+        assert(privateKey is String)
+        assert(privateKey.isNotEmpty())
+
+        val clientId = System.getenv("epic_client_id")
+        assert(clientId is String)
+        assert(clientId.isNotEmpty())
+    }
+
+}

--- a/epic-integration/src/test/kotlin/com/backend/EpicAuthenticationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicAuthenticationTest.kt
@@ -14,10 +14,10 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.function.Executable
 
-class ApplicationTest {
+class EpicAuthenticationTest {
 
     @Test
-    fun testAuthentication() {
+    fun `getEpicAccessToken should not throw any exceptions`() {
         // Asserts that getEpicAccessToken() runs without throwing any exceptions
         assertAll(Executable { runBlocking { getEpicAccessToken() } })
     }

--- a/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
@@ -24,7 +24,13 @@ class EpicCommunicationTest {
 
         @Test
         fun `parseBundleXMLToPatient should parse an xml string to a patient object`() {
-            val patientXML = runBlocking { epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03") }
+            val patientXML = runBlocking { epicCommunication.patientSearch(
+                given = "Derrick",
+                family = "Lin",
+                birthdate = "1973-06-03",
+                format = "xml"
+            )}
+            assert(patientXML is String)
             assert(epicCommunication.parseBundleXMLToPatient(patientXML) is Patient)
         }
     }

--- a/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
@@ -1,15 +1,32 @@
 package com.backend
 
 import com.backend.plugins.EpicCommunication
+import org.hl7.fhir.r4.model.Patient
 import org.junit.Test
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestInstance
 
+
+// Warning: PER_CLASS Lifecycle means that the same EpicCommunicationTest class is used for every nested test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EpicCommunicationTest {
 
     private val epicCommunication = EpicCommunication()
 
-    @Test
-    suspend fun `Patient_Search returns a string`() {
-        assert(epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03") is String)
+    @Nested
+    inner class PatientSearch {
+        private lateinit var patientXML: String
+
+        @Test
+        suspend fun `Patient_Search should return a string`() {
+            patientXML = epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03")
+            assert(patientXML is String)
+        }
+
+        @Test
+        fun `parseBundleXMLToPatient should parse an xml string to a patient object`() {
+            assert(epicCommunication.parseBundleXMLToPatient(patientXML) is Patient)
+        }
     }
 
 }

--- a/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
@@ -1,0 +1,15 @@
+package com.backend
+
+import com.backend.plugins.EpicCommunication
+import org.junit.Test
+
+class EpicCommunicationTest {
+
+    private val epicCommunication = EpicCommunication()
+
+    @Test
+    suspend fun `Patient_Search returns a string`() {
+        assert(epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03") is String)
+    }
+
+}

--- a/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
@@ -19,16 +19,20 @@ class EpicCommunicationTest {
 
         @Test
         fun `Patient_Search should return a string`() {
-            assert(runBlocking { epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03") } is String)
+            assert(runBlocking { epicCommunication.patientSearch(
+                givenName = "Derrick",
+                familyName = "Lin",
+                birthdate = "1973-06-03")
+            } is String)
         }
 
         @Test
         fun `parseBundleXMLToPatient should parse an xml string to a patient object`() {
             val patientXML = runBlocking { epicCommunication.patientSearch(
-                given = "Derrick",
-                family = "Lin",
+                givenName = "Derrick",
+                familyName = "Lin",
                 birthdate = "1973-06-03",
-                format = "xml"
+                outputFormat = "xml"
             )}
             assert(patientXML is String)
             assert(epicCommunication.parseBundleXMLToPatient(patientXML) is Patient)

--- a/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
@@ -1,10 +1,11 @@
 package com.backend
 
 import com.backend.plugins.EpicCommunication
+import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.r4.model.Patient
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestInstance
+import kotlin.test.*
 
 
 // Warning: PER_CLASS Lifecycle means that the same EpicCommunicationTest class is used for every nested test
@@ -15,16 +16,15 @@ class EpicCommunicationTest {
 
     @Nested
     inner class PatientSearch {
-        private lateinit var patientXML: String
 
         @Test
-        suspend fun `Patient_Search should return a string`() {
-            patientXML = epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03")
-            assert(patientXML is String)
+        fun `Patient_Search should return a string`() {
+            assert(runBlocking { epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03") } is String)
         }
 
         @Test
         fun `parseBundleXMLToPatient should parse an xml string to a patient object`() {
+            val patientXML = runBlocking { epicCommunication.patientSearch(given = "Derrick", family = "Lin", birthdate = "1973-06-03") }
             assert(epicCommunication.parseBundleXMLToPatient(patientXML) is Patient)
         }
     }

--- a/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
+++ b/epic-integration/src/test/kotlin/com/backend/EpicCommunicationTest.kt
@@ -2,7 +2,7 @@ package com.backend
 
 import com.backend.plugins.EpicCommunication
 import org.hl7.fhir.r4.model.Patient
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestInstance
 


### PR DESCRIPTION
Closes #81 #82 

Implement basic tests for authentication. Sets up a basic format for including tests in further development. Tests were also added for the EpicCommunication class for the class methods patientSearch and parseBundleXMLToPatient.

The patientSearch arguments were extended with a format variable which defaults as JSON. This now allows for XML extraction as an additional functionality.