### PR TITLE
16 save the data the doctor creates in epic

### DIFF
--- a/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
+++ b/epic-integration/src/main/kotlin/com/backend/plugins/EpicCommunication.kt
@@ -75,13 +75,16 @@ class EpicCommunication {
      * Function to create a patient and save the patient to epics server.
      * In the future, this function should take in parameters, for the
      * different values.
+     * @param givenName string
+     * @param familyName string
+     * @param identifierValue on the format "XXX-XX-XXXX" ("028-27-1234")
      * @return an http response as a string.
      */
-    suspend fun createPatient(): String {
+    suspend fun createPatient(givenName: String, familyName: String, identifierValue: String): String {
         val token: String = runBlocking { getEpicAccessToken() }
         val patient = Patient()
 
-        // Set date
+        // Set birthdate
         val formatter = SimpleDateFormat("dd-MMM-yyyy", Locale.ENGLISH)
         val dateInString = "7-Jun-2013"
         val date = formatter.parse(dateInString)
@@ -92,15 +95,15 @@ class EpicCommunication {
 
         // Set identifier (have not figured out how to give the identifier a value)
         val identifier = Identifier()
-        identifier.setValue("028-27-1234")
+        identifier.setValue(identifierValue)
         identifier.setSystem("urn:oid:2.16.840.1.113883.4.1")
         identifier.setUse(Identifier.IdentifierUse.OFFICIAL)
         patient.setIdentifier(mutableListOf(identifier))
 
         // Set name
         val name = HumanName()
-        name.setFamily("Nordmann")
-        name.setGiven(mutableListOf(StringType("Kari")))
+        name.setFamily(familyName)
+        name.setGiven(mutableListOf(StringType(givenName)))
         name.setUse(HumanName.NameUse.USUAL)
         patient.setName(mutableListOf(name))
 

--- a/epic-integration/src/main/kotlin/com/backend/plugins/Routing.kt
+++ b/epic-integration/src/main/kotlin/com/backend/plugins/Routing.kt
@@ -5,6 +5,7 @@ import io.ktor.application.*
 import io.ktor.freemarker.*
 import io.ktor.response.*
 import io.ktor.request.*
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 
 
@@ -86,6 +87,24 @@ fun Application.personRoute() {
             call.respondTemplate("doctor-create-sykemelding.ftl", data)
         }
 
+        post("/create-patient") {
+            val params = call.receiveParameters()
+
+            val given : String = params["given"]!!
+            val family : String = params["family"]!!
+            val identifierValue : String = params["identifierValue"]!!
+
+            runBlocking { epicCommunication.createPatient(given, family, identifierValue) }
+
+            val data = mapOf("response" to family)
+            call.respondTemplate("create-patient-confirmation.ftl", data)
+        }
+
+//            val given = "GivenB"
+//            val family = "FamilyB"
+//            val p_number = "XXX-XX-XXXX"
+//
+//            epicCommunication.createPatient(given,family,p_number)
     }
 
 }

--- a/epic-integration/src/main/resources/templates/create-patient-confirmation.ftl
+++ b/epic-integration/src/main/resources/templates/create-patient-confirmation.ftl
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Opprett pasient</title>
+</head>
+<body style="text-align: center; font-family: sans-serif">
+<div>
+    <h3>Du har opprettet en pasient</h3>
+    <p>Familienavn: ${response}</p>
+    <br>
+    <a href="/doctor">Gå tilbake til legens side.</a>
+    <br>
+    <a href="/">Gå tilbake til navigasjonsiden.</a>
+</div>
+</body>
+</html>

--- a/epic-integration/src/main/resources/templates/doctor.ftl
+++ b/epic-integration/src/main/resources/templates/doctor.ftl
@@ -10,6 +10,14 @@
     <form action="/messages-from-nav" method="get">
         <input type="submit" value="Se melding">
     </form>
+
+    <h3>Registrer testpasient</h3>
+    <form action="/create-patient" method="post">
+        <input name="given" type="text" placeholder="Given name"><br><br>
+        <input name="family" type="text" placeholder="Family name"><br><br>
+        <input name="identifierValue" type="text" placeholder="xxx-xx-xxxx"><br><br>
+        <input type="submit" value="Registrer pasient">
+    </form>
     <br>
     <br>
     <a href="/">Gå tilbake til navigasjonsiden.</a>


### PR DESCRIPTION
Closes #16 

Implements functionality for creating patients in the doctor-frontend that are stored in the Epic database.

The createPatient method in the EpicCommunication class takes in a given name (fornavn) a family name (etternavn) and an identifierValue (personnummer). 

The identifierValue needs to be a unique and unused number on the format XXX-XX-XXXX. Currently (07.10.2021) the following social security numbers have been used:
159-11-2111
129-11-2111
139-11-2111
149-11-2111
159-11-2111
169-11-2111
118-11-2111

(We may have used other ones as well, but these we know for sure.)

This error message will show up if you try to create a Patient with an already existing Social Security Number (SSN).
![image](https://user-images.githubusercontent.com/69959968/136371313-fcc5546c-57c8-4981-9dd4-cc41fcf19e48.png)
